### PR TITLE
Fix Heroku deployment files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,17 @@
 FROM node:lts
 
-# Install dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends ffmpeg imagemagick webp && apt-get clean
+RUN apt-get update && apt-get install -y --no-install-recommends ffmpeg imagemagick webp && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# Set working directory
 WORKDIR /app
 
-# Copy package files
 COPY package*.json ./
 
-# Install dependencies
-RUN npm install && npm cache clean --force
+RUN npm install --production --legacy-peer-deps && npm cache clean --force
 
-# Copy application code
 COPY . .
 
-# Expose port
 EXPOSE 3000
 
-# Set environment
 ENV NODE_ENV production
 
-# Run command
-CMD ["npm", "run", "start", "index.js"]
+CMD ["node", "--max-old-space-size=512", "--optimize-for-size", "index.js"]

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+worker: node --max-old-space-size=512 --optimize-for-size index.js

--- a/app.json
+++ b/app.json
@@ -1,25 +1,21 @@
 {
   "name": "TRUTH MD",
-  "description": "TRUTH MD, simple Whatsapp bot by Courtney!",
+  "description": "TRUTH MD WhatsApp Bot by Courtney",
   "logo": "https://h.uguu.se/GiYWpWoC.jpg",
-  "keywords": [],
+  "keywords": ["whatsapp", "bot", "baileys", "node"],
   "repository": "https://github.com/Courtney250/TRUTH-MD",
   "stack": "container",
-  "addons": [
-    {
-      "plan": "heroku-postgresql"
+  "env": {
+    "SESSION_ID": {
+      "description": "Your WhatsApp session ID (must start with TRUTH-MD:~)",
+      "value": "",
+      "required": true
+    },
+    "OWNER_NUMBER": {
+      "description": "Your WhatsApp number (e.g. 254101150748)",
+      "required": false
     }
-  ],
-  "scripts": {
-    "start": "node index.js"
   },
-"env": {
-  "SESSION_ID": {
-    "description": "Must begin with 'TRUTH-MD:~'.",
-    "value": "",
-    "required": true
-  }
-},  
   "formation": {
     "worker": {
       "quantity": 1,
@@ -31,10 +27,10 @@
       "url": "heroku/nodejs"
     },
     {
-      "url": "https://github.com/DuckyTeam/heroku-buildpack-imagemagick.git"
+      "url": "https://github.com/jonathanong/heroku-buildpack-ffmpeg-latest"
     },
     {
-      "url": "https://github.com/jonathanong/heroku-buildpack-ffmpeg-latest"
+      "url": "https://github.com/DuckyTeam/heroku-buildpack-imagemagick.git"
     },
     {
       "url": "https://github.com/clhuang/heroku-buildpack-webp-binaries.git"


### PR DESCRIPTION
## Changes

### 1. Add Procfile (NEW)
- Heroku needs this to know how to run the bot
- Uses worker dyno with memory optimization

### 2. Fix Dockerfile
- Fixed broken CMD (was `["npm", "run", "start", "index.js"]` which passes invalid args)
- Now uses `node` directly with memory optimization flags
- Added `--legacy-peer-deps` for dependency compatibility
- Better cleanup of apt cache

### 3. Fix app.json
- Removed `heroku-postgresql` addon (bot does not use Postgres, saves cost)
- Removed invalid `scripts` block (does not belong in app.json)
- Added `OWNER_NUMBER` env var option
- Cleaned up formatting